### PR TITLE
tls: NUL-terminate SNI hostname before the C handshake call

### DIFF
--- a/flare/tls/stream.mojo
+++ b/flare/tls/stream.mojo
@@ -79,6 +79,12 @@ def _c_str(s: String) -> Int:
 
     Returns:
         Integer representation of the ``const char*`` pointer.
+
+    Caution: ``unsafe_ptr`` is only incidentally NUL-terminated for
+    small/static strings; a ``String`` materialised from a ``StringSlice``
+    is not. Callers passing slice-derived strings (e.g. an SNI hostname from
+    ``Url.parse(...).host``) must NUL-terminate first via
+    ``String.as_c_string_slice`` — see ``_do_ssl_connect``.
     """
     return Int(s.unsafe_ptr())
 
@@ -174,11 +180,17 @@ def _do_ssl_free(read lib: OwnedDLHandle, ssl: Int):
     f(ssl)
 
 
-def _do_ssl_connect(read lib: OwnedDLHandle, ssl: Int, sni: String) -> Int:
+def _do_ssl_connect(read lib: OwnedDLHandle, ssl: Int, var sni: String) -> Int:
     var f = lib.get_function[def(Int, Int) thin abi("C") -> c_int](
         "flare_ssl_connect"
     )
-    return Int(f(ssl, _c_str(sni)))
+    # NUL-terminate in place: a `sni` materialised from a StringSlice (the
+    # common case — `Url.parse(...).host`) is not NUL-terminated under
+    # `unsafe_ptr`, so OpenSSL's SSL_set_tlsext_host_name would read past the
+    # hostname and send a corrupted SNI (some servers reply handshake_failure).
+    # `as_c_string_slice` is mutating and `sni` is owned + lives across the call.
+    var cstr = sni.as_c_string_slice()
+    return Int(f(ssl, Int(cstr.unsafe_ptr())))
 
 
 def _do_ssl_read(


### PR DESCRIPTION
## Problem

The HTTPS client fails the TLS handshake against strict servers whenever the SNI hostname is derived from a parsed URL. A concrete reproducer: downloading a HuggingFace LFS file, which 302-redirects to the xet CDN `cas-bridge.xethub.hf.co`:

```mojo
from flare.http import get
var r = get("https://cas-bridge.xethub.hf.co/")
# TlsHandshakeError: error:0A000410:SSL routines::ssl/tls alert handshake failure
```

The same OpenSSL build handshakes with that host fine via `openssl s_client` in every cipher / group / ALPN configuration, so it isn't a parameter-negotiation problem.

## Root cause

`_c_str` returns `String.unsafe_ptr()`, which is **only incidentally NUL-terminated** for small / static (SSO) strings. A `String` materialised from a `StringSlice` — the common case for an SNI hostname taken from `Url.parse(...).host` — has no trailing NUL. `flare_ssl_connect` then passes that pointer to `SSL_set_tlsext_host_name`, which reads past the hostname into adjacent heap bytes and sends a **corrupted SNI**. Strict servers answer with a `handshake_failure` alert (40).

Diagnosis hinge: a string literal host connected, but a **byte-identical** `String(Url.parse(url).host)` failed — isolating it to NUL-termination rather than the handshake parameters.

## Fix

`_do_ssl_connect` now takes an owned `var sni` and NUL-terminates it in place via `as_c_string_slice()` (mutating; the owned `sni` lives across the FFI call) before handing the pointer to `flare_ssl_connect`. Pure-Mojo — no change to the C wrapper.

## Testing

- `HttpClient().get("https://cas-bridge.xethub.hf.co/")`: previously `handshake_failure`, now connects (HTTP 403, expected for an unsigned URL).
- A full HuggingFace weights download (config + ~1 GB safetensors + tokenizer, all over the xet CDN) now succeeds end-to-end.
- `huggingface.co` and localhost TLS paths unaffected.