### PR TITLE
fix: forward caller-supplied Authorization header in H1 and H2c paths

### DIFF
--- a/flare/http/client.mojo
+++ b/flare/http/client.mojo
@@ -710,7 +710,7 @@ struct HttpClient(Movable):
         # Forward caller-supplied headers (skip Host — already set)
         for i in range(extra_headers.len()):
             var k = extra_headers._keys[i]
-            if k.lower() != "host" and k.lower() != "authorization":
+            if k.lower() != "host":
                 wire += k + ": " + extra_headers._values[i] + "\r\n"
 
         if len(body) > 0:

--- a/flare/http/client.mojo
+++ b/flare/http/client.mojo
@@ -711,6 +711,13 @@ struct HttpClient(Movable):
         for i in range(extra_headers.len()):
             var k = extra_headers._keys[i]
             if k.lower() != "host":
+                # Only skip caller's Authorization when _auth_header is already set,
+                # matching the h2/h2c paths (see _build_h2_request_headers).
+                if (
+                    k.lower() == "authorization"
+                    and self._auth_header.byte_length() > 0
+                ):
+                    continue
                 wire += k + ": " + extra_headers._values[i] + "\r\n"
 
         if len(body) > 0:

--- a/flare/http/client.mojo
+++ b/flare/http/client.mojo
@@ -1851,11 +1851,13 @@ def _send_h2c_via_upgrade(
         var lk = k.lower()
         if (
             lk == "host"
-            or lk == "authorization"
             or lk == "connection"
             or lk == "upgrade"
             or lk == "http2-settings"
         ):
+            continue
+        # Only skip caller's Authorization when _auth_header is already set
+        if lk == "authorization" and auth_header.byte_length() > 0:
             continue
         wire += k + ": " + extra_headers._values[i] + "\r\n"
     if len(body) > 0:

--- a/flare/net/_libc.mojo
+++ b/flare/net/_libc.mojo
@@ -666,7 +666,7 @@ def _getaddrinfo(
     var host_copy = host
     return external_call["getaddrinfo", c_int](
         host_copy.as_c_string_slice(),
-        UnsafePointer[UInt8, MutExternalOrigin](unsafe_from_address=0),
+        Optional[UnsafePointer[UInt8, MutExternalOrigin]](None),
         hints.bitcast[NoneType](),
         res_slot.bitcast[NoneType](),
     )

--- a/tests/http/test_unified_http_client.mojo
+++ b/tests/http/test_unified_http_client.mojo
@@ -335,13 +335,15 @@ def test_no_duplicate_authorization_h1() raises:
         exit()
     usleep(200000)
 
-    var base = String("http://127.0.0.1:") + String(Int(port))
+    var url = String("http://127.0.0.1:", Int(port), "/")
     var got = String("")
     var raised = False
     try:
-        # Client credential is set, caller also sets one — stored wins
-        with HttpClient(base, BearerAuth("stored-cred")) as c:
-            var req = Request(method="GET", url="/")
+        # Client credential is set, caller also sets one - stored wins.
+        # Use a full request URL (not base_url + relative): send() takes
+        # req.url as absolute, base_url joining only happens in get/post.
+        with HttpClient(BearerAuth("stored-cred")) as c:
+            var req = Request(method="GET", url=url)
             req.headers.set("Authorization", "Bearer caller-cred")
             got = c.send(req).text()
     except:

--- a/tests/http/test_unified_http_client.mojo
+++ b/tests/http/test_unified_http_client.mojo
@@ -222,10 +222,145 @@ def test_unified_client_bearer_auth_h1() raises:
     assert_equal(got, "Bearer tok_abc")
 
 
+# ── Authorization header forwarding (regression) ─────────────────────────────
+# Regression: HttpClient._do_request() and _send_h2c_via_upgrade() were
+# silently dropping the caller-supplied Authorization header, blocking
+# per-request auth patterns (AWS SigV4, OAuth2 rotation, HMAC signing).
+# These tests prove the caller's Authorization reaches the wire on every
+# path, and that a client credential still wins when both are set.
+
+
+def _count_authorization_header(blob: String) -> Int:
+    """Count the number of times an "Authorization:" header appears in
+    the raw wire bytes. Used to detect the duplicate-header bug where
+    a stored credential AND a caller-set header both land on the wire."""
+    var count = 0
+    var i = 0
+    while i < blob.byte_length():
+        # Find next "Authorization:" (case-insensitive via lowercased compare)
+        if i + 14 <= blob.byte_length():
+            var tag = String("")
+            for j in range(14):
+                tag += String(blob[byte=i + j])
+            if tag.lower() == "authorization:":
+                count += 1
+        i += 1
+    return count
+
+
+def test_caller_authorization_h1_no_credential() raises:
+    """A caller-set Authorization must reach the wire on H1 when the
+    client has no stored credential. This is the primary use case for
+    per-request auth (AWS SigV4, OAuth2, HMAC)."""
+    var srv = HttpServer.bind(SocketAddr.localhost(0))
+    var port = UInt16(srv.local_addr().port)
+
+    var pid = fork()
+    if pid == 0:
+        try:
+            srv.serve(_echo_authorization)
+        except:
+            pass
+        exit()
+    usleep(200000)
+
+    var url = String("http://127.0.0.1:") + String(Int(port)) + String("/")
+    var got = String("")
+    var raised = False
+    try:
+        # No client credential — caller's Authorization must be the only one
+        with HttpClient() as c:
+            var req = Request(method="GET", url=url)
+            req.headers.set("Authorization", "Bearer aws4-token-xyz")
+            got = c.send(req).text()
+    except:
+        raised = True
+
+    _ = kill(pid, SIGKILL)
+    waitpid(pid)
+    assert_true(
+        not raised, "HttpClient().send with caller Authorization raised"
+    )
+    assert_equal(got, "Bearer aws4-token-xyz")
+
+
+def test_caller_authorization_h2c_no_credential() raises:
+    """A caller-set Authorization must reach the wire on the H2c upgrade
+    path when the client has no stored credential."""
+    var srv = HttpServer.bind(SocketAddr.localhost(0))
+    var port = UInt16(srv.local_addr().port)
+
+    var pid = fork()
+    if pid == 0:
+        try:
+            srv.serve(_echo_authorization)
+        except:
+            pass
+        exit()
+    usleep(200000)
+
+    var url = String("http://127.0.0.1:") + String(Int(port)) + String("/")
+    var got = String("")
+    var raised = False
+    try:
+        with HttpClient(prefer_h2c=True) as c:
+            var req = Request(method="GET", url=url)
+            req.headers.set("Authorization", "Bearer aws4-token-h2c")
+            got = c.send(req).text()
+    except:
+        raised = True
+
+    _ = kill(pid, SIGKILL)
+    waitpid(pid)
+    assert_true(
+        not raised,
+        "HttpClient(prefer_h2c=True).send with caller Authorization raised",
+    )
+    assert_equal(got, "Bearer aws4-token-h2c")
+
+
+def test_no_duplicate_authorization_h1() raises:
+    """When the client has a stored credential (BearerAuth) AND the caller
+    sets a per-request Authorization, the stored credential wins and only
+    ONE Authorization header reaches the wire. No duplicate."""
+    var srv = HttpServer.bind(SocketAddr.localhost(0))
+    var port = UInt16(srv.local_addr().port)
+
+    var pid = fork()
+    if pid == 0:
+        try:
+            srv.serve(_echo_authorization)
+        except:
+            pass
+        exit()
+    usleep(200000)
+
+    var base = String("http://127.0.0.1:") + String(Int(port))
+    var got = String("")
+    var raised = False
+    try:
+        # Client credential is set, caller also sets one — stored wins
+        with HttpClient(base, BearerAuth("stored-cred")) as c:
+            var req = Request(method="GET", url="/")
+            req.headers.set("Authorization", "Bearer caller-cred")
+            got = c.send(req).text()
+    except:
+        raised = True
+
+    _ = kill(pid, SIGKILL)
+    waitpid(pid)
+    assert_true(not raised, "HttpClient with both creds raised")
+    # Stored credential must be the one the server sees, not the caller's
+    assert_equal(got, "Bearer stored-cred")
+
+
 def main() raises:
     test_unified_client_http_url_round_trip()
     test_unified_client_module_level_get()
     test_unified_client_h2c_prior_knowledge()
     test_unified_client_basic_auth_h2c()
     test_unified_client_bearer_auth_h1()
-    print("test_unified_http_client: 5 passed")
+    test_caller_authorization_h1_no_credential()
+    test_caller_authorization_h2c_no_credential()
+    test_no_duplicate_authorization_h1()
+    print("test_unified_http_client: 8 passed")


### PR DESCRIPTION
## Problem

`HttpClient._do_request()` and `_send_h2c_via_upgrade()` silently drop the `Authorization` header when callers set it via `req.headers.set("Authorization", ...)`. The header never reaches the wire.

This blocks legitimate per-request auth patterns:
- **AWS Signature V4** — signature is computed per-request from body, headers, and timestamp
- **OAuth2 short-lived tokens** — refresh frequently, differ per endpoint
- **HMAC request signing** — digest covers request body, must be set just before sending

## Root cause

Two methods unconditionally filtered `authorization` from forwarded caller headers, expecting auth to always flow through `HttpClient._auth_header`:

1. `_do_request()` line 713 — the main HTTP/1.1 path
2. `_send_h2c_via_upgrade()` line 1854 — the H2C upgrade path

## Fix

**H1 path:** Remove `authorization` from the skip condition entirely. When `_auth_header` is empty (the default), callers must be able to set `Authorization` via `req.headers`.

**H2c path:** Only skip caller's `Authorization` when `_auth_header` is already set — matching the existing pattern in `_build_h2_request_headers()` (line 1619-1623).

Both paths remain compatible with `BasicAuth`/`BearerAuth`: those set `_auth_header` which is still emitted on line 707-708 (H1) and 1847-1848 (H2c).

## Testing

Reproduced against moto S3 mock server. Before the fix, any request with a per-request Authorization header returns 403 (header absent from wire). After the fix, the header reaches the server and requests succeed.