### PR TITLE
fix(deps) update recipe.yaml to pull json 0.2.1 for b2 compatibility

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -38,11 +38,10 @@ package:
 source:
   # flare source
   - path: .
-  # json source (inlined; v0.1.5's recipe pins the same Mojo nightly we
-  # ship against, see ``ehsanmok/json@v0.1.5/recipe.yaml``).
+  # json source (inlined).
   - git: https://github.com/ehsanmok/json.git
     target_directory: json-src
-    tag: v0.1.5
+    tag: v0.2.1
 
 build:
   script:


### PR DESCRIPTION
flare builds against b2 now, but the recipe.yaml pulls in json package that won't compile due to gpu function changes