### PR TITLE
fix(http): decode Response.text() as UTF-8 in one pass

### DIFF
--- a/flare/http/response.mojo
+++ b/flare/http/response.mojo
@@ -177,12 +177,13 @@ struct ResponseImpl[B: Body = InlineBody](Movable):
         """
         if len(self.body) == 0:
             return ""
-        # Build string from raw bytes.
-        # Mojo String stores UTF-8 internally; slice copy is safe.
-        var out = String(capacity=len(self.body) + 1)
-        for b in self.body:
-            out += chr(Int(b))
-        return out^
+        # Bulk-copy the body in ONE pass. The previous loop appended
+        # ``chr(Int(b))`` per byte, which was wrong twice over: ``chr``
+        # maps each byte to its *code point*, so any multi-byte UTF-8
+        # sequence was re-encoded as Latin-1 (a 2-byte "é" came back as
+        # two mojibake characters); and ``String +=`` reallocates, making
+        # the decode O(n^2) -- a 358 KB body took 20s+ at 100% CPU.
+        return String(unsafe_from_utf8=Span[UInt8, _](self.body))
 
     def json(self) raises -> Value:
         """Parse the body as JSON and return a ``json.Value``.

--- a/tests/http/test_http.mojo
+++ b/tests/http/test_http.mojo
@@ -60,6 +60,32 @@ def test_response_text_ascii() raises:
     assert_equal(r.text(), "Hello")
 
 
+def test_response_text_utf8_multibyte() raises:
+    """A multi-byte UTF-8 body must round-trip, not decode as Latin-1.
+
+    Regression: decoding byte-by-byte via ``chr`` treats every byte as a
+    code point, so "café — 日本語" came back as mojibake with one
+    character per *byte* instead of per code point.
+    """
+    var src = String("café — 日本語 😀")
+    var body = List[UInt8]()
+    var bs = src.as_bytes()
+    for i in range(len(bs)):
+        body.append(bs[i])
+    var r = Response(status=200, body=body^)
+    assert_equal(r.text(), src)
+
+
+def test_response_text_large_body() raises:
+    """A large body decodes in full (and in one pass, not O(n^2))."""
+    var n = 256 * 1024
+    var body = List[UInt8](capacity=n)
+    for _ in range(n):
+        body.append(UInt8(ord("x")))
+    var r = Response(status=200, body=body^)
+    assert_equal(len(r.text().as_bytes()), n)
+
+
 # ── Status constants ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
`text()` built its result with `out += chr(Int(b))` over the body bytes. That is wrong twice over:

- **Mis-decodes multi-byte UTF-8.** `chr` maps a byte to the code point of the same value, so every non-ASCII sequence was effectively decoded as Latin-1 and re-encoded as UTF-8. A body containing "café" came back as "cafÃ©" — one character per *byte* instead of per code point, despite the docstring promising a UTF-8 decode.

- **Quadratic.** `String +=` reallocates, so the decode is O(n^2) in the body length. A 358 KB response took 20s+ at 100% CPU.

The body is already UTF-8 bytes and `String` stores UTF-8 internally, so the whole loop collapses into the bulk constructor already used elsewhere in the tree (e.g. `flare/crypto/hmac.mojo`):

    String(unsafe_from_utf8=Span[UInt8, _](self.body))

Adds two regression tests to `tests/http/test_http.mojo`: a multi-byte round-trip (accented + CJK + astral-plane) that fails on the old path, and a 256 KB body that guards the one-pass copy.


This was generated with Claude.