### PR TITLE
fix(reactor): unregister must not raise when EPOLL_CTL_DEL fails

### DIFF
--- a/flare/runtime/reactor.mojo
+++ b/flare/runtime/reactor.mojo
@@ -403,7 +403,7 @@ struct Reactor(Movable):
             fd: Previously-registered fd.
 
         Raises:
-            NetworkError: If ``fd`` is not registered or the syscall fails.
+            NetworkError: If ``fd`` is not registered.
         """
         if fd not in self._registered:
             raise NetworkError("fd " + String(fd) + " is not registered", 0)
@@ -412,8 +412,21 @@ struct Reactor(Movable):
             var ev = stack_allocation[EPOLL_EVENT_SIZE, UInt8]()
             for i in range(EPOLL_EVENT_SIZE):
                 ev.unsafe_offset(i).unsafe_write(UInt8(0))
-            if _epoll_ctl(self._fd, EPOLL_CTL_DEL, fd, ev) < c_int(0):
-                raise _os_error("epoll_ctl DEL")
+            # EPOLL_CTL_DEL can legitimately fail here, and neither
+            # failure is fatal: if whoever took ownership of the fd has
+            # already closed it, the kernel auto-removed it from the
+            # epoll set and DEL returns EBADF; if it was never armed,
+            # DEL returns ENOENT. Both mean "this fd is no longer
+            # watched" -- exactly the post-state unregister() wants.
+            #
+            # Raising instead would skip the ``_registered.pop(fd)``
+            # below and leave a stale bookkeeping entry. Because the
+            # kernel hands out the lowest free descriptor, the very next
+            # accept(2) reuses that number and ``register`` then rejects
+            # it as already-registered, silently dropping the
+            # connection. The kqueue branch below already ignores its
+            # EV_DELETE result for exactly this reason.
+            _ = _epoll_ctl(self._fd, EPOLL_CTL_DEL, fd, ev)
         else:
             # Delete both possible filters. EV_DELETE on a non-registered
             # filter returns ENOENT, which we ignore.

--- a/tests/runtime/test_reactor.mojo
+++ b/tests/runtime/test_reactor.mojo
@@ -104,6 +104,49 @@ def test_unregister_unknown_fd_raises() raises:
         r.unregister(c_int(999))
 
 
+def test_unregister_after_close_succeeds() raises:
+    """Unregister() must tolerate an fd the owner already closed.
+
+    Ownership hand-off (e.g. a WebSocket upgrade passing the socket to a
+    connection object that closes it) can close the fd before the
+    reactor unregisters it. The kernel auto-removes a closed fd from the
+    epoll set, so ``EPOLL_CTL_DEL`` then fails with EBADF; kqueue's
+    ``EV_DELETE`` returns ENOENT. Both mean "no longer watched", so
+    neither is fatal and the bookkeeping entry must still be dropped.
+    """
+    var r = Reactor()
+    var listener = TcpListener.bind(SocketAddr.localhost(0))
+    var fd = listener._socket.fd
+    r.register(fd, UInt64(1), INTEREST_READ)
+    listener.close()
+    r.unregister(fd)
+    assert_false(r.is_registered(fd))
+    assert_equal(r.registered_count(), 0)
+
+
+def test_unregister_after_close_frees_fd_for_reuse() raises:
+    """A stale entry left by a failed DEL would poison the recycled fd.
+
+    The kernel hands out the lowest free descriptor, so the next socket
+    very often reuses the number just closed. If ``unregister`` bailed
+    out before ``_registered.pop(fd)``, ``register`` would reject that
+    recycled fd as already-registered and the new connection would be
+    dropped.
+    """
+    var r = Reactor()
+    var first = TcpListener.bind(SocketAddr.localhost(0))
+    var fd = first._socket.fd
+    r.register(fd, UInt64(1), INTEREST_READ)
+    first.close()
+    r.unregister(fd)
+
+    var second = TcpListener.bind(SocketAddr.localhost(0))
+    r.register(second._socket.fd, UInt64(2), INTEREST_READ)
+    assert_true(r.is_registered(second._socket.fd))
+    r.unregister(second._socket.fd)
+    second.close()
+
+
 def test_modify_unknown_fd_raises() raises:
     """Modify() on a never-registered fd raises."""
     var r = Reactor()


### PR DESCRIPTION
`Reactor.unregister` raises `_os_error("epoll_ctl DEL")` whenever the DEL syscall fails. Two failures there are routine rather than fatal:

- **EBADF** — whoever took ownership of the fd already closed it, so the kernel auto-removed it from the epoll set. This happens on any ownership hand-off; the case that surfaced it was a WebSocket upgrade passing the socket to a connection object that closes it when the handler returns.
- **ENOENT** — the fd was never armed.

Both describe exactly the post-state `unregister()` is trying to reach. Raising skips the `_registered.pop(fd)` at the end of the function and leaves a stale bookkeeping entry behind. Because the kernel hands out the lowest free descriptor, the very next `accept(2)` typically reuses that number, and `register` then rejects it as already-registered — so a perfectly good new connection is silently dropped.

The kqueue branch directly below already ignores its `EV_DELETE` result for this exact reason ("ENOENT on unregistered filter is not a fatal error"). This makes the epoll branch match, so the two backends present the same contract. The `Raises:` docstring is narrowed to match: the only remaining raise is the not-registered guard.

Adds `test_unregister_after_close_succeeds` and
`test_unregister_after_close_frees_fd_for_reuse` to tests/runtime/test_reactor.mojo. The second is the one that matters — it re-registers after the recycled-fd hand-back, which is where the stale entry actually bites.


Created with Claude.