### PR TITLE
feat(ws): expose the handshake Origin on WsConnection

### DIFF
--- a/examples/basic/ws_server.mojo
+++ b/examples/basic/ws_server.mojo
@@ -152,10 +152,10 @@ def accept_and_upgrade(
     """
     var server_stream = srv._listener.accept()
     var peer = server_stream.peer_addr()
-    var key = _read_upgrade_request(server_stream)
-    var accept = _compute_accept_srv(key)
+    var upgrade = _read_upgrade_request(server_stream)
+    var accept = _compute_accept_srv(upgrade.key)
     _send_upgrade_response(server_stream, accept)
-    return WsConnection(server_stream^, peer)
+    return WsConnection(server_stream^, peer, upgrade.origin.copy())
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/flare/ws/server.mojo
+++ b/flare/ws/server.mojo
@@ -159,7 +159,22 @@ def _str_find_srv(s: String, sub: String) -> Int:
     return -1
 
 
-def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> String:
+@fieldwise_init
+struct _WsUpgradeRequest(Movable):
+    """The handshake fields the server keeps from an Upgrade request.
+
+    Fields:
+        key: The ``Sec-WebSocket-Key`` header value (always present; the
+            parsers raise when it is missing).
+        origin: The ``Origin`` header value, or empty when the client
+            sent none. Non-browser clients routinely omit it.
+    """
+
+    var key: String
+    var origin: String
+
+
+def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> _WsUpgradeRequest:
     """Parse an HTTP WebSocket Upgrade request from a byte buffer.
 
     Identical logic to ``_read_upgrade_request`` but reads from a
@@ -170,7 +185,7 @@ def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> String:
         data: Raw HTTP/1.1 Upgrade request bytes.
 
     Returns:
-        The ``Sec-WebSocket-Key`` header value.
+        The retained handshake fields (``Sec-WebSocket-Key`` + ``Origin``).
 
     Raises:
         NetworkError: If the request is malformed or missing required headers.
@@ -193,6 +208,7 @@ def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> String:
     _ = read_line(data, pos)
 
     var ws_key = String("")
+    var ws_origin = String("")
     var found_upgrade = False
     var found_connection = False
 
@@ -215,6 +231,11 @@ def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> String:
         )
         if k == "sec-websocket-key":
             ws_key = v
+        elif k == "origin":
+            # Retained verbatim, not validated: the library has no way to
+            # know which origins a given deployment trusts. Handlers get
+            # it via ``WsConnection.origin`` and apply their own policy.
+            ws_origin = v
         elif k == "upgrade" and _lower_srv(v) == "websocket":
             found_upgrade = True
         elif k == "connection" and "upgrade" in _lower_srv(v):
@@ -229,10 +250,10 @@ def _parse_ws_upgrade_bytes(data: Span[UInt8, _]) raises -> String:
         raise NetworkError(
             "WebSocket upgrade request missing Sec-WebSocket-Key"
         )
-    return ws_key^
+    return _WsUpgradeRequest(ws_key^, ws_origin^)
 
 
-def _read_upgrade_request(mut stream: TcpStream) raises -> String:
+def _read_upgrade_request(mut stream: TcpStream) raises -> _WsUpgradeRequest:
     """Read an HTTP upgrade request and return the ``Sec-WebSocket-Key``.
 
     Reads until the blank line terminating HTTP headers.
@@ -241,7 +262,7 @@ def _read_upgrade_request(mut stream: TcpStream) raises -> String:
         stream: Accepted TCP stream.
 
     Returns:
-        The ``Sec-WebSocket-Key`` header value.
+        The retained handshake fields (``Sec-WebSocket-Key`` + ``Origin``).
 
     Raises:
         NetworkError: If the upgrade request is malformed or missing the key.
@@ -250,6 +271,7 @@ def _read_upgrade_request(mut stream: TcpStream) raises -> String:
     _ = _read_line_srv(stream)
 
     var ws_key = String("")
+    var ws_origin = String("")
     var found_upgrade = False
     var found_connection = False
 
@@ -272,6 +294,11 @@ def _read_upgrade_request(mut stream: TcpStream) raises -> String:
         )
         if k == "sec-websocket-key":
             ws_key = v
+        elif k == "origin":
+            # Retained verbatim, not validated: the library has no way to
+            # know which origins a given deployment trusts. Handlers get
+            # it via ``WsConnection.origin`` and apply their own policy.
+            ws_origin = v
         elif k == "upgrade" and _lower_srv(v) == "websocket":
             found_upgrade = True
         elif k == "connection" and "upgrade" in _lower_srv(v):
@@ -286,7 +313,7 @@ def _read_upgrade_request(mut stream: TcpStream) raises -> String:
         raise NetworkError(
             "WebSocket upgrade request missing Sec-WebSocket-Key"
         )
-    return ws_key^
+    return _WsUpgradeRequest(ws_key^, ws_origin^)
 
 
 def _send_upgrade_response(mut stream: TcpStream, accept: String) raises:
@@ -323,6 +350,7 @@ struct WsConnection(Movable):
     Fields:
         _stream: The underlying TCP stream.
         _peer: The remote socket address.
+        origin: The handshake ``Origin`` header (empty when absent).
 
     Example:
         ```mojo
@@ -337,10 +365,40 @@ struct WsConnection(Movable):
 
     var _stream: TcpStream
     var _peer: SocketAddr
+    var origin: String
+    """The ``Origin`` header sent with the upgrade handshake, or empty
+    when the client sent none.
 
-    def __init__(out self, var stream: TcpStream, peer: SocketAddr):
+    Exposed so a handler can enforce a same-origin (or allow-list)
+    policy of its own. Browsers do NOT apply the same-origin policy to
+    ``ws://`` connects and send no preflight, so **any** page a user
+    visits can open a WebSocket to a server this process is running --
+    including one bound to loopback. ``Origin`` is the only signal in
+    the handshake that says which site opened the socket.
+
+    Trust it only as far as browsers make it trustworthy: a browser sets
+    it and script cannot forge it, but a non-browser client sends
+    whatever it likes (or nothing at all). It authenticates the *page*,
+    never the user.
+
+    Example:
+        ```mojo
+        def on_connect(mut conn: WsConnection) raises:
+            if conn.origin != "https://app.example.com":
+                conn.close(WsCloseCode.POLICY_VIOLATION)
+                return
+        ```
+    """
+
+    def __init__(
+        out self,
+        var stream: TcpStream,
+        peer: SocketAddr,
+        var origin: String = String(""),
+    ):
         self._stream = stream^
         self._peer = peer
+        self.origin = origin^
 
     def __deinit__(deinit self):
         self._stream.close()
@@ -637,10 +695,10 @@ struct WsServer(Movable):
             var stream = self._listener.accept()
             var peer = stream.peer_addr()
             try:
-                var key = _read_upgrade_request(stream)
-                var accept = _compute_accept_srv(key)
+                var upgrade = _read_upgrade_request(stream)
+                var accept = _compute_accept_srv(upgrade.key)
                 _send_upgrade_response(stream, accept)
-                var conn = WsConnection(stream^, peer)
+                var conn = WsConnection(stream^, peer, upgrade.origin.copy())
                 handler.on_connection(conn)
             except e:
                 print("[ws] connection error: " + String(e))
@@ -668,10 +726,10 @@ def _handle_ws_connection(
     Upgrade errors are swallowed so the accept loop continues.
     """
     try:
-        var key = _read_upgrade_request(stream)
-        var accept = _compute_accept_srv(key)
+        var upgrade = _read_upgrade_request(stream)
+        var accept = _compute_accept_srv(upgrade.key)
         _send_upgrade_response(stream, accept)
-        var conn = WsConnection(stream^, peer)
+        var conn = WsConnection(stream^, peer, upgrade.origin.copy())
         handler(conn)
     except e:
         print("[ws] connection error: " + String(e))

--- a/tests/ws/test_ws.mojo
+++ b/tests/ws/test_ws.mojo
@@ -402,9 +402,18 @@ def test_ws_echo_roundtrip() raises:
 # 4. Exchanges raw WsFrame wire bytes on the client side.
 
 
-def _send_upgrade_request_raw(mut stream: TcpStream, host: String) raises:
-    """Send a minimal HTTP/1.1 upgrade request from a raw TCP stream."""
+def _send_upgrade_request_raw(
+    mut stream: TcpStream, host: String, origin: String = ""
+) raises:
+    """Send a minimal HTTP/1.1 upgrade request from a raw TCP stream.
+
+    ``origin`` is omitted from the request entirely when empty, matching
+    a non-browser client.
+    """
     var key = "dGhlIHNhbXBsZSBub25jZQ=="  # well-known test key
+    var origin_line = String("")
+    if origin != "":
+        origin_line = "Origin: " + origin + "\r\n"
     var req = (
         "GET / HTTP/1.1\r\n"
         + "Host: "
@@ -416,6 +425,7 @@ def _send_upgrade_request_raw(mut stream: TcpStream, host: String) raises:
         + key
         + "\r\n"
         + "Sec-WebSocket-Version: 13\r\n"
+        + origin_line
         + "\r\n"
     )
     var b = req.as_bytes()
@@ -470,10 +480,10 @@ def test_ws_server_text_echo_loopback() raises:
     # ── Server: accept + handshake
     var server_stream = srv._listener.accept()
     var srv_peer = server_stream.peer_addr()
-    var key = _read_upgrade_request(server_stream)
-    var accept = _compute_accept_srv(key)
+    var upgrade = _read_upgrade_request(server_stream)
+    var accept = _compute_accept_srv(upgrade.key)
     _send_upgrade_response(server_stream, accept)
-    var conn = WsConnection(server_stream^, srv_peer)
+    var conn = WsConnection(server_stream^, srv_peer, upgrade.origin.copy())
 
     # ── Client: discard 101, then send masked TEXT frame
     _drain_101(raw_client)
@@ -520,10 +530,10 @@ def test_ws_server_binary_echo_loopback() raises:
 
     var server_stream = srv._listener.accept()
     var srv_peer2 = server_stream.peer_addr()
-    var key = _read_upgrade_request(server_stream)
-    var accept = _compute_accept_srv(key)
+    var upgrade = _read_upgrade_request(server_stream)
+    var accept = _compute_accept_srv(upgrade.key)
     _send_upgrade_response(server_stream, accept)
-    var conn = WsConnection(server_stream^, srv_peer2)
+    var conn = WsConnection(server_stream^, srv_peer2, upgrade.origin.copy())
 
     _drain_101(raw_client)
 
@@ -568,10 +578,10 @@ def test_ws_server_unmasked_frame_rejected() raises:
 
     var server_stream = srv._listener.accept()
     var srv_peer3 = server_stream.peer_addr()
-    var key = _read_upgrade_request(server_stream)
-    var accept = _compute_accept_srv(key)
+    var upgrade = _read_upgrade_request(server_stream)
+    var accept = _compute_accept_srv(upgrade.key)
     _send_upgrade_response(server_stream, accept)
-    var conn = WsConnection(server_stream^, srv_peer3)
+    var conn = WsConnection(server_stream^, srv_peer3, upgrade.origin.copy())
 
     _drain_101(raw_client)
 
@@ -589,6 +599,93 @@ def test_ws_server_unmasked_frame_rejected() raises:
     with assert_raises():
         _ = conn.recv()
 
+    raw_client.close()
+    srv.close()
+
+
+# ── Handshake Origin ──────────────────────────────────────────────────────────
+
+
+def _upgrade_bytes(origin_line: String) -> List[UInt8]:
+    """A well-formed upgrade request, optionally carrying an Origin."""
+    var req = (
+        "GET /chat HTTP/1.1\r\n"
+        + "Host: localhost\r\n"
+        + "Upgrade: websocket\r\n"
+        + "Connection: Upgrade\r\n"
+        + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        + "Sec-WebSocket-Version: 13\r\n"
+        + origin_line
+        + "\r\n"
+    )
+    var out = List[UInt8]()
+    var b = req.as_bytes()
+    for i in range(len(b)):
+        out.append(b[i])
+    return out^
+
+
+def test_upgrade_parse_captures_origin() raises:
+    """A present Origin header is retained verbatim."""
+    from flare.ws.server import _parse_ws_upgrade_bytes
+
+    var raw = _upgrade_bytes("Origin: https://app.example.com\r\n")
+    var up = _parse_ws_upgrade_bytes(Span[UInt8, _](raw))
+    assert_equal(up.origin, "https://app.example.com")
+    assert_equal(up.key, "dGhlIHNhbXBsZSBub25jZQ==")
+
+
+def test_upgrade_parse_origin_absent_is_empty() raises:
+    """A request without an Origin yields the empty string, not an error.
+
+    Non-browser clients routinely omit it, so this must stay a
+    successful parse.
+    """
+    from flare.ws.server import _parse_ws_upgrade_bytes
+
+    var up = _parse_ws_upgrade_bytes(Span[UInt8, _](_upgrade_bytes("")))
+    assert_equal(up.origin, "")
+    assert_equal(up.key, "dGhlIHNhbXBsZSBub25jZQ==")
+
+
+def test_upgrade_parse_origin_header_name_case_insensitive() raises:
+    """HTTP field names are case-insensitive (RFC 9110 5.1)."""
+    from flare.ws.server import _parse_ws_upgrade_bytes
+
+    var raw = _upgrade_bytes("ORIGIN: https://Example.COM\r\n")
+    var up = _parse_ws_upgrade_bytes(Span[UInt8, _](raw))
+    # Name matched case-insensitively; the value keeps its own case,
+    # since origin comparison is the handler's policy to define.
+    assert_equal(up.origin, "https://Example.COM")
+
+
+def test_ws_connection_carries_handshake_origin() raises:
+    """End-to-end: the Origin reaches the handler on WsConnection."""
+    from flare.ws import WsServer, WsConnection
+    from flare.ws.server import (
+        _read_upgrade_request,
+        _send_upgrade_response,
+        _compute_accept_srv,
+    )
+    from flare.net import SocketAddr
+    from flare.tcp import TcpStream
+
+    var srv = WsServer.bind(SocketAddr.localhost(0))
+    var port = srv.local_addr().port
+
+    var raw_client = TcpStream.connect(SocketAddr.localhost(port))
+    _send_upgrade_request_raw(raw_client, "localhost", "https://evil.test")
+
+    var server_stream = srv._listener.accept()
+    var srv_peer = server_stream.peer_addr()
+    var upgrade = _read_upgrade_request(server_stream)
+    var accept = _compute_accept_srv(upgrade.key)
+    _send_upgrade_response(server_stream, accept)
+    var conn = WsConnection(server_stream^, srv_peer, upgrade.origin.copy())
+
+    assert_equal(conn.origin, "https://evil.test")
+
+    _drain_101(raw_client)
     raw_client.close()
     srv.close()
 


### PR DESCRIPTION
Browsers do not apply the same-origin policy to `ws://` connects and send no preflight, so any page a user visits can open a WebSocket to a server this process is running -- including one bound to loopback. The `Origin` header is the only signal in the handshake that says which site opened the socket, and today the server parses it and throws it away: `_read_upgrade_request` walks every header but returns only the `Sec-WebSocket-Key`, and `WsConnection` carries just `_stream` + `_peer`. A handler therefore has no way to reject a cross-site connect.

This threads it through:

- `_WsUpgradeRequest` -- a small carrier for the handshake fields the server keeps (`key` + `origin`). Both parsers now return it, so the byte-buffer and stream paths stay mirror images of each other as their docstrings promise.
- `WsConnection.origin`, populated on both `WsServer` accept paths (the struct-handler loop and `_handle_ws_connection`).

The value is retained verbatim, never validated: the library has no way to know which origins a deployment trusts, so policy stays with the handler. Absent `Origin` yields the empty string rather than an error -- non-browser clients routinely omit it, and rejecting those would break every existing non-browser client.

The new constructor parameter is defaulted, so all existing `WsConnection(stream^, peer)` call sites keep compiling. Callers of the two parsers move from `key` to `.key` (3 test sites, 1 example); the fuzz harness already discards the result and is unchanged.

Tests: three byte-level parser cases (present / absent / case-insensitive field name) plus an end-to-end loopback assert that the Origin reaches the handler on `WsConnection`.


Written with Claude