### PR TITLE
fix(ws): decode TEXT payloads per code point, not per byte

### DIFF
--- a/flare/ws/frame.mojo
+++ b/flare/ws/frame.mojo
@@ -495,10 +495,7 @@ struct WsFrame(Movable, Writable):
         """
         if not _is_valid_utf8(self.payload):
             raise WsProtocolError("TEXT frame payload is not valid UTF-8")
-        var s = String(capacity=len(self.payload) + 1)
-        for b in self.payload:
-            s += chr(Int(b))
-        return s^
+        return String(unsafe_from_utf8=Span[UInt8, _](self.payload))
 
     def write_to[W: Writer](self, mut writer: W):
         writer.write(

--- a/tests/ws/test_ws.mojo
+++ b/tests/ws/test_ws.mojo
@@ -290,6 +290,19 @@ def test_encode_decode_roundtrip_text() raises:
     assert_equal(result.consumed, len(wire))
 
 
+def test_encode_decode_roundtrip_text_utf8() raises:
+    """A non-ASCII text frame must decode per code point, not per byte.
+
+    Covers 2-, 3- and 4-byte sequences: decoding byte-by-byte via ``chr``
+    maps each byte to its own code point, so the payload came back with
+    one character per byte.
+    """
+    var src = String("café 日本語 😀")
+    var wire = WsFrame.text(src).encode()
+    var result = WsFrame.decode_one(Span[UInt8, _](wire))
+    assert_equal(result.frame.text_payload(), src)
+
+
 def test_encode_decode_roundtrip_binary() raises:
     """Encode then decode a binary frame must reproduce all bytes."""
     var payload = List[UInt8](capacity=256)


### PR DESCRIPTION
## Summary

`WsFrame.text_payload()` validated its payload as UTF-8 per RFC 6455 8.1 and then decoded it with `s += chr(Int(b))` per byte, which maps each byte to the code point of the same value. Every non-ASCII TEXT frame came back with one character per byte:

```mojo
WsFrame.text("café 日本語").text_payload()  # -> "cafÃ© æ¥æ¬èª"
```

This is user-visible on both sides of the connection today. `WsClient.recv()` builds its `WsMessage` from `text_payload()` (`flare/ws/client.mojo:766`), and both `WsServer` echo paths go through it (`flare/ws/server.mojo:513`, and the documented handler example at line 331).

The validation on the preceding line already guarantees well-formed UTF-8, so the loop collapses into the bulk constructor with no new failure mode. Worth stating explicitly, since it is the reason this substitution is safe here and not everywhere: `String(unsafe_from_utf8=...)` runs the stdlib validator internally despite its name (documented in this tree at `docs/benchmark.md:705-708` and `flare/http/proto/ascii.mojo:51-61`), and on invalid input that validator aborts the process under `-D ASSERT=all`. It cannot fire here because line 496 has already rejected invalid payloads.

Same shape as the `Response.text()` fix in #9.

## Not in scope

`Request.text()` (`flare/http/request.mojo:419`) and `MultipartPart.text()` (`flare/http/multipart.mojo:232`, reached publicly via `MultipartForm.value()`) carry the identical loop and are identically broken, confirmed locally. Their bytes are caller-supplied rather than pre-validated, so the plain substitution would trade mojibake for a remotely-triggerable abort on an assert-enabled build. They need validate-then-copy and are tracked separately.

## Test plan

- [x] `test_encode_decode_roundtrip_text_utf8` added, covering 2-, 3- and 4-byte sequences; verified it FAILS on the unfixed decoder and passes with the fix
- [x] `pixi run test-ws` 34/34
- [x] `pixi run test-ws-permessage-deflate` 12, `test-ws-h2` 6, `test-ws-h2-roundtrip` 1, `test-ws-stateful-handler` 1, `test-conformance-ws` OK
- [x] `pixi run format-check` clean

Made with [Cursor](https://cursor.com)